### PR TITLE
refactor CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,7 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 find_library(MHTD NAMES microhttpd)
 if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
     message(STATUS "microhttpd NOT found: disable http server")
-else()
-    add_definitions("-DHAVE_MICROHTTPD")
+    add_definitions("-DCONF_NO_HTTPD")
 endif()
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,21 +22,12 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 
 option(XMR-STAK_UNSUPPORTED_GCC "Allow compile with gcc <5.1 and >=4.8" OFF)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if(XMR-STAK_UNSUPPORTED_GCC)
-        # gcc 4.8 is the first version with acceptable c++11 support
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-            message(FATAL_ERROR "GCC version must be at least 4.8!")
-        else()
-            message(WARNING "XMR-STAK_UNSUPPORTED_GCC=ON, we can't give any warrenty!")
-        endif()
-    else()
-        # gcc 5.1 is the first GNU version without CoW strings
-        # https://github.com/fireice-uk/xmr-stak-nvidia/pull/10#issuecomment-290821792
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-            message(FATAL_ERROR "GCC version must be at least 5.1! You can use '-DXMR-STAK_UNSUPPORTED_GCC=ON' to irgnore this error.")
-        endif()
-    endif()
+# gcc 5.1 is the first GNU version without CoW strings
+# https://github.com/fireice-uk/xmr-stak-nvidia/pull/10#issuecomment-290821792
+# If you remove this guard to compile with older gcc versions the miner will produce
+# a high rate of wrong shares.
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
+    message(FATAL_ERROR "GCC version must be at least 5.1!")
 endif()
 
 set(BUILD_TYPE "Release;Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,223 @@
 project(xmr-stak-nvidia)
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.0.1)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-        message(FATAL_ERROR "GCC version must be at least 5.1!")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+        message(FATAL_ERROR "GCC version must be at least 4.8!")
     endif()
 endif()
 
-find_library(MHTD NAMES microhttpd)
-if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
-    message(FATAL_ERROR "libmicrohttpd is required")
+# enforce C++11
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "install prefix" FORCE)
+endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+# help to find cuda on systems with a software module system
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CUDA_ROOT}")
+# allow user to extent CMAKE_PREFIX_PATH via environment variable
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+
+################################################################################
+# CMake user options
+################################################################################
+
+set(BUILD_TYPE "Release;Debug")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
+
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${BUILD_TYPE}")
+
+option(XMR-STAK_LARGEGRID "Support large CUDA block count > 128" ON)
+if(XMR-STAK_LARGEGRID)
+    add_definitions("-DXMRMINER_LARGEGRID=${XMR-STAK_LARGEGRID}")
 endif()
 
-find_package(OpenSSL REQUIRED)
+set(DEVICE_COMPILER "nvcc")
+set(CUDA_COMPILER "${DEVICE_COMPILER}" CACHE STRING "Select the device compiler")
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    list(APPEND DEVICE_COMPILER "clang")
+endif()
+
+set_property(CACHE CUDA_COMPILER PROPERTY STRINGS "${DEVICE_COMPILER}")
+
+################################################################################
+# Find CUDA
+################################################################################
+
+find_package(CUDA 7.5 REQUIRED)
+set(LIBS ${LIBS} ${CUDA_LIBRARIES})
+
+set(XMR-STAK_THREADS 0 CACHE STRING "Set maximum number of threads (for compile time optimization)")
+if(NOT XMR-STAK_THREADS EQUAL 0)
+    message(STATUS "xmr-stak-nvidia: set max threads per block to ${XMR-STAK_THREADS}")
+    add_definitions("-DXMRMINER_THREADS=${XMR-STAK_THREADS}")
+endif()
+
+set(CUDA_ARCH "20;30;35;37;50;52;60;61;62" CACHE STRING "Set GPU architecture (semicolon separated list, e.g. '-DCUDA_ARCH=20;35;60')")
+
+# validate architectures (only numbers are allowed)
+foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
+    string(REGEX MATCH "^[0-9]+$" IS_NUMBER ${CUDA_ARCH})
+    if(NOT IS_NUMBER)
+        message(FATAL_ERROR "Defined compute architecture '${CUDA_ARCH_ELEM}' in "
+                            "'${CUDA_ARCH}' is not an integral number, use e.g. '30' (for compute architecture 3.0).")
+    endif()
+    unset(IS_NUMBER)
+
+    if(${CUDA_ARCH_ELEM} LESS 20)
+        message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                            "Use '20' (for compute architecture 2.0) or higher.")
+    endif()
+endforeach()
+
+option(CUDA_SHOW_REGISTER "Show registers used for each kernel and compute architecture" OFF)
+option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps" OFF)
+
+if("${CUDA_COMPILER}" STREQUAL "clang")
+    set(LIBS ${LIBS} cudart_static)
+    set(CLANG_BUILD_FLAGS "-O3 -x cuda --cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
+    # activation usage of FMA
+    set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} -ffp-contract=fast")
+
+    if(CUDA_SHOW_REGISTER)
+        set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} -Xcuda-ptxas -v")
+    endif(CUDA_SHOW_REGISTER)
+
+    if(CUDA_KEEP_FILES)
+        set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} -save-temps=${PROJECT_BINARY_DIR}")
+    endif(CUDA_KEEP_FILES)
+
+    foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
+        # set flags to create device code for the given architectures
+        set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} --cuda-gpu-arch=sm_${CUDA_ARCH_ELEM}")
+    endforeach()
+
+elseif("${CUDA_COMPILER}" STREQUAL "nvcc")
+
+    foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
+        # set flags to create device code for the given architecture
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
+            "--generate-code arch=compute_${CUDA_ARCH_ELEM},code=sm_${CUDA_ARCH_ELEM}")
+    endforeach()
+
+    # give each thread an independent default stream
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --default-stream per-thread")
+
+    option(CUDA_SHOW_CODELINES "Show kernel lines in cuda-gdb and cuda-memcheck" OFF)
+
+    if(CUDA_SHOW_CODELINES)
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --source-in-ptx -lineinfo)
+        set(CUDA_KEEP_FILES ON CACHE BOOL "activate keep files" FORCE)
+    endif(CUDA_SHOW_CODELINES)
+
+    if(CUDA_SHOW_REGISTER)
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -Xptxas=-v)
+    endif(CUDA_SHOW_REGISTER)
+
+    if(CUDA_KEEP_FILES)
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}")
+    endif(CUDA_KEEP_FILES)
+
+else()
+    message(FATAL_ERROR "selected CUDA compiler '${CUDA_COMPILER}' is not supported")
+endif()
+
+################################################################################
+# Find PThreads
+################################################################################
+
+find_package(Threads REQUIRED)
+set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+
+################################################################################
+# Find microhttpd
+################################################################################
+
+find_library(MHTD NAMES microhttpd)
+if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
+    message(STATUS "microhttpd NOT found: disable http server")
+else()
+    add_definitions("-DHAVE_MICROHTTPD")
+endif()
+
+###############################################################################
+# Find OpenSSL
+###############################################################################
+
+find_package(OpenSSL)
 include_directories(${OPENSSL_INCLUDE_DIR})
-find_package(CUDA REQUIRED)
+set(LIBS ${LIBS} ${OPENSSL_LIBRARIES})
+if(NOT OPENSSL_FOUND)
+    add_definitions("-DCONF_NO_TLS")
+endif()
 
-#set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CUDA_NVCC_FLAGS "")
+################################################################################
+# Compile & Link
+################################################################################
+
+include_directories(.)
+
+# activate sse2 and aes-ni
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes")
+
 file(GLOB CUDASRCFILES "nvcc_code/*.cu")
-cuda_add_library(cuda_code ${CUDASRCFILES})
+file(GLOB SRCFILES "*.cpp" "crypto/*.cpp")
+file(GLOB SRCFILES_CRYPTO "crypto/*.c")
 
-set(CMAKE_C_FLAGS "-DNDEBUG -march=westmere -O3 -m64 -s")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
+if("${CUDA_COMPILER}" STREQUAL "clang")
+    # build device code with clang
+    add_library(xmr-stak-nvidiaCuda
+        STATIC
+        ${CUDASRCFILES}
+    )
+    set_target_properties(xmr-stak-nvidiaCuda PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
+    set_target_properties(xmr-stak-nvidiaCuda PROPERTIES LINKER_LANGUAGE CXX)
+    set_source_files_properties(${CUDASRCFILES} PROPERTIES LANGUAGE CXX)
+else()
+    # build device code with nvcc
+    cuda_add_library(xmr-stak-nvidiaCuda
+        STATIC
+        ${CUDASRCFILES}
+    )
+endif()
+
+add_library(xmr-stak-nvidiaCrypto
+    STATIC
+    ${SRCFILES_CRYPTO}
+)
+set_property(TARGET xmr-stak-nvidiaCrypto PROPERTY C_STANDARD 99)
+
+add_executable(xmr-stak-nvidia
+    ${SRCFILES}
+)
+
+# for gnu compiler <5.1 wee need to activate c++11 by explicit for cuda and all cpp files
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1))
+    set_target_properties(xmr-stak-nvidiaCuda PROPERTIES COMPILE_FLAGS -std=c++11)
+    set_target_properties(xmr-stak-nvidia PROPERTIES COMPILE_FLAGS -std=c++11)
+endif()
 
 set(EXECUTABLE_OUTPUT_PATH "bin")
 
-file(GLOB SOURCES "crypto/*.c" "crypto/*.cpp" "*.cpp")
+target_link_libraries(xmr-stak-nvidia ${LIBS} xmr-stak-nvidiaCuda xmr-stak-nvidiaCrypto)
 
-add_executable(xmr-stak-nvidia ${SOURCES})
-target_link_libraries(xmr-stak-nvidia cuda_code pthread microhttpd crypto ssl)
- 
+################################################################################
+# Install
+################################################################################
 
+install(TARGETS xmr-stak-nvidia
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
+# avoid overwrite of user defined settings
+# install `config.txt`if file not exists in `${CMAKE_INSTALL_PREFIX}/bin`
+install(CODE " \
+    if(NOT EXISTS ${CMAKE_INSTALL_PREFIX}/bin/config.txt)\n   \
+        file(INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/config.txt   \
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)\n        \
+    endif()"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,6 @@ project(xmr-stak-nvidia)
 
 cmake_minimum_required(VERSION 3.0.1)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-        message(FATAL_ERROR "GCC version must be at least 4.8!")
-    endif()
-endif()
-
 # enforce C++11
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -25,6 +19,25 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 ################################################################################
 # CMake user options
 ################################################################################
+
+option(XMR-STAK_UNSUPPORTED_GCC "Allow compile with gcc <5.1 and >=4.8" OFF)
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(XMR-STAK_UNSUPPORTED_GCC)
+        # gcc 4.8 is the first version with acceptable c++11 support
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+            message(FATAL_ERROR "GCC version must be at least 4.8!")
+        else()
+            message(WARNING "XMR-STAK_UNSUPPORTED_GCC=ON, we can't give any warrenty!")
+        endif()
+    else()
+        # gcc 5.1 is the first GNU version without CoW strings
+        # https://github.com/fireice-uk/xmr-stak-nvidia/pull/10#issuecomment-290821792
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
+            message(FATAL_ERROR "GCC version must be at least 5.1! You can use '-DXMR-STAK_UNSUPPORTED_GCC=ON' to irgnore this error.")
+        endif()
+    endif()
+endif()
 
 set(BUILD_TYPE "Release;Debug")
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ elseif("${CUDA_COMPILER}" STREQUAL "nvcc")
     foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
         # set flags to create device code for the given architecture
         set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
-            "--generate-code arch=compute_${CUDA_ARCH_ELEM},code=sm_${CUDA_ARCH_ELEM}")
+            "--generate-code arch=compute_${CUDA_ARCH_ELEM},code=sm_${CUDA_ARCH_ELEM} --generate-code arch=compute_${CUDA_ARCH_ELEM},code=compute_${CUDA_ARCH_ELEM}")
     endforeach()
 
     # give each thread an independent default stream

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -27,7 +27,7 @@
 #include "console.h"
 #include "donate-level.h"
 
-#ifdef HAVE_MICROHTTPD
+#ifndef CONF_NO_HTTPD
 #	include "httpd.h"
 #endif
 
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-#ifdef HAVE_MICROHTTPD
+#ifndef CONF_NO_HTTPD
 	if(jconf::inst()->GetHttpdPort() != 0)
 	{
 		if (!httpd::inst()->start_daemon())

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -26,7 +26,10 @@
 #include "jconf.h"
 #include "console.h"
 #include "donate-level.h"
-#include "httpd.h"
+
+#ifdef HAVE_MICROHTTPD
+#	include "httpd.h"
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -109,6 +112,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+#ifdef HAVE_MICROHTTPD
 	if(jconf::inst()->GetHttpdPort() != 0)
 	{
 		if (!httpd::inst()->start_daemon())
@@ -117,6 +121,7 @@ int main(int argc, char *argv[])
 			return 0;
 		}
 	}
+#endif
 
 	printer::inst()->print_str("-------------------------------------------------------------------\n");
 	printer::inst()->print_str("XMR-Stak-NVIDIA mining software, NVIDIA Version.\n");

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -21,6 +21,8 @@
   *
   */
 
+#ifdef HAVE_MICROHTTPD
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -142,3 +144,4 @@ bool httpd::start_daemon()
 	return true;
 }
 
+#endif

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -21,7 +21,7 @@
   *
   */
 
-#ifdef HAVE_MICROHTTPD
+#ifndef CONF_NO_HTTPD
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
## Changes
- add support for full compile with clang (host and device code)
- allow compiling without microhttpd
- allow compiling without OpenSSL
- install `config.txt` with command `make install`
- default build binary for all available cuda architectures
- set minimal gcc from 5.1 to 4.8

## Tests:
- [x] compile with gcc 4.8.2, cmake 3.0.1 and cuda 7.5
- [x] runtime tests
- [x] compile without microhttpd