### PR TITLE
always build feature complete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,10 +143,15 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 # Find microhttpd
 ################################################################################
 
+option(MICROHTTPD_REQUIRED "Enable or disable the requirement of microhttp (http deamon)" ON)
 find_library(MHTD NAMES microhttpd)
 if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
-    message(STATUS "microhttpd NOT found: disable http server")
-    add_definitions("-DCONF_NO_HTTPD")
+    if(MICROHTTPD_REQUIRED)
+        message(FATAL_ERROR "microhttpd NOT found: use `-DMICROHTTPD_REQUIRED=OFF` to build without http deamon support")
+    else()
+        message(STATUS "microhttpd NOT found: disable http server")
+        add_definitions("-DCONF_NO_HTTPD")
+    endif()
 else()
     set(LIBS ${LIBS} ${MHTD})
 endif()
@@ -155,11 +160,19 @@ endif()
 # Find OpenSSL
 ###############################################################################
 
+option(OpenSSL_REQUIRED "Enable or disable the requirement of OpenSSL" ON)
 find_package(OpenSSL)
-include_directories(${OPENSSL_INCLUDE_DIR})
-set(LIBS ${LIBS} ${OPENSSL_LIBRARIES})
-if(NOT OPENSSL_FOUND)
-    add_definitions("-DCONF_NO_TLS")
+if(OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    set(LIBS ${LIBS} ${OPENSSL_LIBRARIES})
+else()
+    if(OpenSSL_REQUIRED)
+        message(FATAL_ERROR "OpenSSL NOT found: use `-DOpenSSL_REQUIRED=OFF` to build without SSL support")
+    else()
+        if(NOT OPENSSL_FOUND)
+            add_definitions("-DCONF_NO_TLS")
+        endif()
+    endif()
 endif()
 
 ################################################################################


### PR DESCRIPTION
## Change
- throw an error if a compile dependancy is not fullfilled
- add options to disable hard compile dependancies

close #14 

## Note

I used the names `*_REQUIRED` to mirroring the fact that if someone disable the requirement of a dependancy it is still build with those if they can be found.

## Expert Option
All libraries which are searched with cmake `find_package` can be disabled with `CMAKE_DISABLE_FIND_PACKAGE_<PackageName>`. If for example `OpenSSL` is disabled the error is thrown that the used needs to disable the requirement.
example how to disable `OpenSSL` also if the library is available: `cmake ../xmr-stak-nvidia/ -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON -DOpenSSL_REQUIRED=OFF`

# Test

- [x] compiled test
- [x] runtime test