### PR TITLE
auto adjust valid gpu config

### DIFF
--- a/autoAdjust.hpp
+++ b/autoAdjust.hpp
@@ -1,0 +1,134 @@
+
+#pragma once
+
+#include "autoAdjust.hpp"
+
+#include "nvcc_code/cryptonight.h"
+#include "jconf.h"
+#include "console.h"
+
+#include <vector>
+#include <cstdio>
+#include <iostream>
+
+class autoAdjust
+{    
+public:
+
+    autoAdjust()
+    {
+        size_t n = jconf::inst()->GetThreadCount();
+                // evaluate config parameter for if auto adjustment is needed
+        for(size_t i = 0; i < n; i++)
+        {
+            jconf::thd_cfg cfg;
+            jconf::inst()->GetThreadConfig(i, cfg);
+            cfgVec.push_back(cfg);
+        }
+    }
+
+    /** print the adjusted values if needed
+     *
+     * Routine exit the application and print the adjusted values if needed else
+     * nothing is happened.
+     */
+    void validateThreadConfig()
+    {
+        if( !needToAdjust() )
+            return;
+
+        printf("\nYour config file contains values defined with `null`.\n");
+        printf("The miner evaluates your system and prints a suggestion for the section `gpu_threads_conf` to the terminal.\n");
+        printf("The values are not optimal, please optimize the values by your own based on the suggestion.\n");
+        printf("Please copy past the values to your config.\n");
+        printf("\n***************************************************************\n\n");
+        // evaluate config parameter for if auto adjustment is needed
+        for(auto& cfg : cfgVec)
+        {
+            nvid_ctx ctx;
+
+            ctx.device_id = (int)cfg.id;
+            ctx.device_blocks = (int)cfg.blocks;
+            ctx.device_threads = (int)cfg.threads;
+            ctx.device_bfactor = (int)cfg.bfactor;
+            ctx.device_bsleep = (int)cfg.bsleep;
+
+        // set all evice option those marked as auto (-1) to a valid value
+#ifndef _WIN32
+            if(ctx.device_bfactor == -1)
+            {
+                ctx.device_bfactor = 0;
+            }
+            if(ctx.device_bsleep == -1)
+            {
+                ctx.device_bsleep = 0;
+            }
+#else
+            // windows pass, try to avoid that windows kills the miner if the gpu is blocked for 2 seconds
+            if(ctx.device_bfactor == -1)
+            {
+                ctx.device_bfactor = 6;
+            }
+            if(ctx.device_bsleep == -1)
+            {
+                ctx.device_bsleep = 25;
+            }
+#endif
+            if( cuda_get_deviceinfo(&ctx) != 1 )
+            {
+                printer::inst()->print_msg(L0, "Setup failed for GPU %d. Exitting.\n", cfg.id);
+                std::exit(0);
+            }
+            nvidCtxVec.push_back(ctx);
+        }
+
+        printThreadConfig();
+        printf("\n**************** Press ENTER to exit! ***********************\n");
+        std::cin.sync();
+        std::cin.get();
+        std::exit(0);
+    }
+
+private:
+
+    /** check if one thread needs to be adjusted
+     *
+     * @return true if adjustment is needed else false
+     */
+    bool needToAdjust()
+    {
+        for(auto& cfg : cfgVec)
+        {
+            if(
+                cfg.bfactor == -1 ||
+                cfg.blocks == -1 ||
+                cfg.bsleep == -1 ||
+                cfg.threads == -1
+            )
+                return true;
+        }
+        return false;
+    }
+    
+    void printThreadConfig()
+    {
+        printf("\"gpu_threads_conf\" : [\n");
+        int i = 0;
+        for(auto& ctx : nvidCtxVec)
+        {
+            printf("   { \"index\" : %i, \"threads\" : %i, \"blocks\" : %i, \"bfactor\" : %i, \"bsleep\" :  %i, \"affine_to_cpu\" : %s},\n",
+                ctx.device_id,
+                ctx.device_threads,
+                ctx.device_blocks,
+                ctx.device_bfactor,
+                ctx.device_bsleep,
+                cfgVec[i].cpu_aff ? "true" : "false"
+            );
+            ++i;
+        }
+        printf("],\n");
+    }
+
+    std::vector<jconf::thd_cfg> cfgVec;
+    std::vector<nvid_ctx> nvidCtxVec;
+};

--- a/autoAdjust.hpp
+++ b/autoAdjust.hpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 #include <cstdio>
-#include <iostream>
+#include <sstream>
 
 class autoAdjust
 {    
@@ -17,12 +17,15 @@ public:
 
     autoAdjust()
     {
-        size_t n = jconf::inst()->GetThreadCount();
-                // evaluate config parameter for if auto adjustment is needed
-        for(size_t i = 0; i < n; i++)
+        int deviceCount = 0;
+        if(cuda_get_devicecount(&deviceCount) == 0)
+            std::exit(0);
+        // evaluate config parameter for if auto adjustment is needed
+        for(int i = 0; i < deviceCount; i++)
         {
             jconf::thd_cfg cfg;
             jconf::inst()->GetThreadConfig(i, cfg);
+            cfg.cpu_aff = 0;
             cfgVec.push_back(cfg);
         }
     }
@@ -32,47 +35,32 @@ public:
      * Routine exit the application and print the adjusted values if needed else
      * nothing is happened.
      */
-    void validateThreadConfig()
+    void printConfig()
     {
-        if( !needToAdjust() )
-            return;
-
-        printf("\nYour config file contains values defined with `null`.\n");
-        printf("The miner evaluates your system and prints a suggestion for the section `gpu_threads_conf` to the terminal.\n");
-        printf("The values are not optimal, please optimize the values by your own based on the suggestion.\n");
-        printf("Please copy past the values to your config.\n");
-        printf("\n***************************************************************\n\n");
+        printer::inst()->print_str("\nThe configuration for `gpu_threads_conf` in your config file is `null`.\n");
+        printer::inst()->print_str("The miner evaluates your system and prints a suggestion for the section `gpu_threads_conf` to the terminal.\n");
+        printer::inst()->print_str("The values are not optimal, please try to tweak the values based on the suggestion.\n");
+        printer::inst()->print_str("Please copy past the block within the asterisks to your config.\n");
+        printer::inst()->print_str("\n**************** Copy&Past ****************\n\n");
+        int i = 0;
         // evaluate config parameter for if auto adjustment is needed
         for(auto& cfg : cfgVec)
         {
             nvid_ctx ctx;
 
-            ctx.device_id = (int)cfg.id;
-            ctx.device_blocks = (int)cfg.blocks;
-            ctx.device_threads = (int)cfg.threads;
-            ctx.device_bfactor = (int)cfg.bfactor;
-            ctx.device_bsleep = (int)cfg.bsleep;
+            ctx.device_id = i;
+            // -1 trigger auto adjustment
+            ctx.device_blocks = -1;
+            ctx.device_threads = -1;
 
         // set all evice option those marked as auto (-1) to a valid value
 #ifndef _WIN32
-            if(ctx.device_bfactor == -1)
-            {
-                ctx.device_bfactor = 0;
-            }
-            if(ctx.device_bsleep == -1)
-            {
-                ctx.device_bsleep = 0;
-            }
+            ctx.device_bfactor = 0;
+            ctx.device_bsleep = 0;
 #else
             // windows pass, try to avoid that windows kills the miner if the gpu is blocked for 2 seconds
-            if(ctx.device_bfactor == -1)
-            {
-                ctx.device_bfactor = 6;
-            }
-            if(ctx.device_bsleep == -1)
-            {
-                ctx.device_bsleep = 25;
-            }
+            ctx.device_bfactor = 6;
+            ctx.device_bsleep = 25;
 #endif
             if( cuda_get_deviceinfo(&ctx) != 1 )
             {
@@ -80,53 +68,32 @@ public:
                 std::exit(0);
             }
             nvidCtxVec.push_back(ctx);
+            ++i;
         }
 
         printThreadConfig();
-        printf("\n**************** Press ENTER to exit! ***********************\n");
-        std::cin.sync();
-        std::cin.get();
-        std::exit(0);
+        printer::inst()->print_str("\n**************** Copy&Past ****************\n");
+
     }
 
 private:
-
-    /** check if one thread needs to be adjusted
-     *
-     * @return true if adjustment is needed else false
-     */
-    bool needToAdjust()
-    {
-        for(auto& cfg : cfgVec)
-        {
-            if(
-                cfg.bfactor == -1 ||
-                cfg.blocks == -1 ||
-                cfg.bsleep == -1 ||
-                cfg.threads == -1
-            )
-                return true;
-        }
-        return false;
-    }
     
     void printThreadConfig()
     {
-        printf("\"gpu_threads_conf\" : [\n");
+        printer::inst()->print_str("\"gpu_threads_conf\" : [\n");
         int i = 0;
         for(auto& ctx : nvidCtxVec)
         {
-            printf("   { \"index\" : %i, \"threads\" : %i, \"blocks\" : %i, \"bfactor\" : %i, \"bsleep\" :  %i, \"affine_to_cpu\" : %s},\n",
-                ctx.device_id,
-                ctx.device_threads,
-                ctx.device_blocks,
-                ctx.device_bfactor,
-                ctx.device_bsleep,
-                cfgVec[i].cpu_aff ? "true" : "false"
-            );
+            std::stringstream conf;
+            conf << "  { \"index\" : " << ctx.device_id << ",\n" <<
+                "    \"threads\" : " << ctx.device_threads << ", \"blocks\" : " << ctx.device_blocks << ",\n" <<
+                "    \"bfactor\" : " << ctx.device_bfactor << ", \"bsleep\" :  " << ctx.device_bsleep << ",\n" <<
+                "    \"affine_to_cpu\" : " << ( cfgVec[i].cpu_aff ? "true" : "false" ) << ",\n" <<
+                "  },\n";
+            printer::inst()->print_str(conf.str().c_str());
             ++i;
         }
-        printf("],\n");
+        printer::inst()->print_str("],\n");
     }
 
     std::vector<jconf::thd_cfg> cfgVec;

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -100,9 +100,13 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	// check if auto adjustment is needed
-	autoAdjust adjust;
-	adjust.validateThreadConfig();
+	if(jconf::inst()->NeedsAutoconf())
+	{
+		autoAdjust adjust;
+		adjust.validateThreadConfig();
+		win_exit();
+		return 0;
+	}
 
 	if (!minethd::self_test())
 	{

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -21,6 +21,7 @@
   *
   */
 
+#include "autoAdjust.hpp"
 #include "executor.h"
 #include "minethd.h"
 #include "jconf.h"
@@ -98,6 +99,10 @@ int main(int argc, char *argv[])
 		win_exit();
 		return 0;
 	}
+
+	// check if auto adjustment is needed
+	autoAdjust adjust;
+	adjust.validateThreadConfig();
 
 	if (!minethd::self_test())
 	{

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 	if(jconf::inst()->NeedsAutoconf())
 	{
 		autoAdjust adjust;
-		adjust.validateThreadConfig();
+		adjust.printConfig();
 		win_exit();
 		return 0;
 	}

--- a/config.txt
+++ b/config.txt
@@ -8,14 +8,14 @@
  * index         - GPU index number usually starts from 0.
  * threads       - Number of GPU threads (nothing to do with CPU threads).
  * blocks        - Number of GPU blocks (nothing to do with CPU threads).
- * bfactor       - Enables running the Cryptonight kernel in smaller pieces. 
+ * bfactor       - Enables running the Cryptonight kernel in smaller pieces.
  *                 Increase if you want to reduce GPU lag. Recommended setting on GUI systems - 8
- * bsleep        - Insert a delay of X microseconds between kernel launches. 
+ * bsleep        - Insert a delay of X microseconds between kernel launches.
  *                 Increase if you want to reduce GPU lag. Recommended setting on GUI systems - 100
  * affine_to_cpu - This will affine the thread to a CPU. This can make a GPU miner play along nicer with a CPU miner.
  */
 "gpu_threads_conf" : [ 
-	{ "index" : 0, "threads" : 17, "blocks" : 60, "bfactor" : 0, "bsleep" :  0, "affine_to_cpu" : false},
+	{ "index" : 0, "threads" : null, "blocks" : null, "bfactor" : null, "bsleep" :  null, "affine_to_cpu" : false},
 ],
 
 /*

--- a/config.txt
+++ b/config.txt
@@ -1,8 +1,3 @@
-/* 
- * Number of GPUs that you have in your system. Each GPU will get its own CPU thread.
- */
-"gpu_thread_num" : 1,
-
 /*
  * GPU configuration. You should play around with threads and blocks as the fastest settings will vary.
  * index         - GPU index number usually starts from 0.
@@ -13,10 +8,18 @@
  * bsleep        - Insert a delay of X microseconds between kernel launches.
  *                 Increase if you want to reduce GPU lag. Recommended setting on GUI systems - 100
  * affine_to_cpu - This will affine the thread to a CPU. This can make a GPU miner play along nicer with a CPU miner.
+ *
+ * On the first run the miner will look at your system and suggest a basic configuration that will work,
+ * you can try to tweak it from there to get the best performance.
+ * 
+ * A filled out configuration should look like this:
+ * "gpu_threads_conf" : 
+ * [
+ *     { "index" : 0, "threads" : 17, "blocks" : 60, "bfactor" : 0, "bsleep" :  0, "affine_to_cpu" : false},
+ * ],
  */
-"gpu_threads_conf" : [ 
-	{ "index" : 0, "threads" : null, "blocks" : null, "bfactor" : null, "bsleep" :  null, "affine_to_cpu" : false},
-],
+"gpu_threads_conf" : 
+null,
 
 /*
  * TLS Settings

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -134,38 +134,26 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	if(!gid->IsNumber() || gid->GetInt() < 0)
 		return false;
 
-	if(blocks->IsNumber() && blocks->GetInt() > 0)
-		cfg.blocks = blocks->GetInt();
-	else if(blocks->IsNull())
-		cfg.blocks = -1;
-	else
+	if(!blocks->IsNumber() || blocks->GetInt() < 0)
 		return false;
 
-	if(threads->IsNumber() && threads->GetInt() > 0)
-		cfg.threads = threads->GetInt();
-	else if(threads->IsNull())
-		cfg.threads = -1;
-	else
+	if(!threads->IsNumber() || threads->GetInt() < 0)
 		return false;
 
-	if(bfactor->IsNumber() && bfactor->GetInt() >= 0)
-		cfg.bfactor = bfactor->GetInt();
-	else if(bfactor->IsNull())
-		cfg.bfactor = -1;
-	else
+	if(!bfactor->IsNumber() || bfactor->GetInt() < 0)
 		return false;
 
-	if(bsleep->IsNumber() && bsleep->GetInt() >= 0)
-		cfg.bsleep = bsleep->GetInt();
-	else if(bsleep->IsNull())
-		cfg.bsleep = -1;
-	else
+	if(!bsleep->IsNumber() || bsleep->GetInt() < 0)
 		return false;
 
 	if(!aff->IsUint64() && !aff->IsBool())
 		return false;
 
 	cfg.id = gid->GetInt();
+	cfg.blocks = blocks->GetInt();
+	cfg.threads = threads->GetInt();
+	cfg.bfactor = bfactor->GetInt();
+	cfg.bsleep = bsleep->GetInt();
 
 	if(aff->IsNumber())
 		cfg.cpu_aff = aff->GetInt();

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -134,26 +134,38 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	if(!gid->IsNumber() || gid->GetInt() < 0)
 		return false;
 
-	if(!blocks->IsNumber() || blocks->GetInt() < 0)
+	if(blocks->IsNumber() && blocks->GetInt() > 0)
+		cfg.blocks = blocks->GetInt();
+	else if(blocks->IsNull())
+		cfg.blocks = -1;
+	else
 		return false;
 
-	if(!threads->IsNumber() || threads->GetInt() < 0)
+	if(threads->IsNumber() && threads->GetInt() > 0)
+		cfg.threads = threads->GetInt();
+	else if(threads->IsNull())
+		cfg.threads = -1;
+	else
 		return false;
 
-	if(!bfactor->IsNumber() || bfactor->GetInt() < 0)
+	if(bfactor->IsNumber() && bfactor->GetInt() >= 0)
+		cfg.bfactor = bfactor->GetInt();
+	else if(bfactor->IsNull())
+		cfg.bfactor = -1;
+	else
 		return false;
 
-	if(!bsleep->IsNumber() || bsleep->GetInt() < 0)
+	if(bsleep->IsNumber() && bsleep->GetInt() >= 0)
+		cfg.bsleep = bsleep->GetInt();
+	else if(bsleep->IsNull())
+		cfg.bsleep = -1;
+	else
 		return false;
 
 	if(!aff->IsUint64() && !aff->IsBool())
 		return false;
 
 	cfg.id = gid->GetInt();
-	cfg.blocks = blocks->GetInt();
-	cfg.threads = threads->GetInt();
-	cfg.bfactor = bfactor->GetInt();
-	cfg.bsleep = bsleep->GetInt();
 
 	if(aff->IsNumber())
 		cfg.cpu_aff = aff->GetInt();

--- a/jconf.h
+++ b/jconf.h
@@ -15,10 +15,10 @@ public:
 
 	struct thd_cfg {
 		uint32_t id;
-		uint32_t blocks;
-		uint32_t threads;
-		uint32_t bfactor;
-		uint32_t bsleep;
+		int32_t blocks;
+		int32_t threads;
+		int32_t bfactor;
+		int32_t bsleep;
 		int32_t cpu_aff;
 	};
 

--- a/jconf.h
+++ b/jconf.h
@@ -15,10 +15,10 @@ public:
 
 	struct thd_cfg {
 		uint32_t id;
-		int32_t blocks;
-		int32_t threads;
-		int32_t bfactor;
-		int32_t bsleep;
+		uint32_t blocks;
+		uint32_t threads;
+		uint32_t bfactor;
+		uint32_t bsleep;
 		int32_t cpu_aff;
 	};
 

--- a/jconf.h
+++ b/jconf.h
@@ -24,6 +24,7 @@ public:
 
 	size_t GetThreadCount();
 	bool GetThreadConfig(size_t id, thd_cfg &cfg);
+	bool NeedsAutoconf();
 
 	bool GetTlsSetting();
 	bool TlsSecureAlgos();

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -153,7 +153,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg)
 	ctx.device_threads = (int)cfg.threads;
 	ctx.device_bfactor = (int)cfg.bfactor;
 	ctx.device_bsleep = (int)cfg.bsleep;
-	
+
 	oWorkThd = std::thread(&minethd::work_main, this);
 }
 

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -153,7 +153,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg)
 	ctx.device_threads = (int)cfg.threads;
 	ctx.device_bfactor = (int)cfg.bfactor;
 	ctx.device_bsleep = (int)cfg.bsleep;
-
+	
 	oWorkThd = std::thread(&minethd::work_main, this);
 }
 

--- a/nvcc_code/cryptonight.h
+++ b/nvcc_code/cryptonight.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 typedef struct {
 	int device_id;
 	const char *device_name;

--- a/nvcc_code/cryptonight.h
+++ b/nvcc_code/cryptonight.h
@@ -27,6 +27,12 @@ typedef struct {
 
 extern "C" {
 
+/** get device count
+ *
+ * @param deviceCount[out] cuda device count
+ * @return error code: 0 == error is occurred, 1 == no error
+ */
+int cuda_get_devicecount( int* deviceCount);
 int cuda_get_deviceinfo(nvid_ctx *ctx);
 int cryptonight_extra_cpu_init(nvid_ctx *ctx);
 void cryptonight_extra_cpu_set_data( nvid_ctx* ctx, const void *data, uint32_t len);


### PR DESCRIPTION
The current `config.txt`is not running on all devices. It could be hard for non advanced users to find a first valid configuration.

This pull request adds the possibility that the miner adjust the device setting to find a valid run able configuration. The user can start to tune the settings based on the auto adjust settings.
The auto adjust function is **not** searching for the best setting, only a valid configuration based on the gpu type, operating system and currently available memory is searched.

## Changes
- allow `threads`, `blocks`, `bfactor` and `bsleep` to be auto adjusted by the miner
  - default on windows:
    - `bsleep=25`
    - `bfactor=6`
  - default on linux
    - `bsleep=0`
    - `bfactor`6`
  - default `blocks` 3 * SMX (multi processor count)
  - default `threads <=64` auto selected depends on the architecture and the available gpu memory
- change default `config.txt` to use auto adjusted gpu value
- add class `autoAdjust`
- ~~print used device configuration with and memory usage with `debug_level : 3` (important information to tune the miner to the maximum hash rate)~~
- ~~compile CUDA as C++11 (missed to enable it in #10)~~

## Tests
- [x] runtime 2 different device in one system (both auto adjust)
- [x] runtime 4 devices full and partly auto adjusted
