### PR TITLE
add build documentation for win64

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ VDZK2WlPa9hHu0ApcviQN11HOhHzFTbGVOji5irkng1ZswoKVS+8ZlOtvFfYWhu8
 -----END PGP SIGNATURE-----
 
 ```
+## Compile for Windows
+
+- see [WINCOMPILE.md](WINCOMPILE.md)
 
 ## Compile on Linux (Debian-based distros)
 

--- a/WINCOMPILE.md
+++ b/WINCOMPILE.md
@@ -14,7 +14,7 @@
 - download VS2017 Community and install from [https://www.visualstudio.com/downloads/](https://www.visualstudio.com/downloads/)
 - during the install chose the components
   - `Desktop development with C++` (left side)
-  - `Toolset for Visual Studio C++ 2015.3 v140...` (left side)
+  - `Toolset for Visual Studio C++ 2015.3 v140...` (right side)
 
 ### Cuda 8.0+
 
@@ -39,7 +39,7 @@
 ### Microhttpd for Win32
 
 - download the precompiled binary from [http://ftpmirror.gnu.org/libmicrohttpd/](http://ftpmirror.gnu.org/libmicrohttpd/)
-- tested version: [microhttpd-0.9.55](http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-0.9.55-w32-bin.zip)
+- tested version: [libmicrohttpd-0.9.55-w32-bin](http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-0.9.55-w32-bin.zip)
 - unzip microhttpd to ``C:\xmr-stak-dep`
 
 ### Validate the Dependency Folder
@@ -48,23 +48,92 @@
 - run
    ```
    cd c:\xmr-stak-dep
-   tree
+   tree .
    ```
 - the result should have the same structure
   ```
     C:\XMR-STAK-DEP
-    └───microhttpd
+    └───libmicrohttpd-0.9.55-w32-bin
+        ├───x86
+        │   ├───MinGW
+        │   │   ├───shared
+        │   │   │   └───mingw32
+        │   │   │       ├───bin
+        │   │   │       ├───include
+        │   │   │       └───lib
+        │   │   │           └───pkgconfig
+        │   │   ├───shared-xp
+        │   │   │   └───mingw32
+        │   │   │       ├───bin
+        │   │   │       ├───include
+        │   │   │       └───lib
+        │   │   │           └───pkgconfig
+        │   │   ├───static
+        │   │   │   └───mingw32
+        │   │   │       ├───include
+        │   │   │       └───lib
+        │   │   │           └───pkgconfig
+        │   │   └───static-xp
+        │   │       └───mingw32
+        │   │           ├───include
+        │   │           └───lib
+        │   │               └───pkgconfig
+        │   ├───VS2013
+        │   │   ├───Release-dll
+        │   │   ├───Release-dll-xp
+        │   │   ├───Release-static
+        │   │   └───Release-static-xp
+        │   ├───VS2015
+        │   │   ├───Debug-dll
+        │   │   ├───Debug-dll-xp
+        │   │   ├───Debug-static
+        │   │   ├───Debug-static-xp
+        │   │   ├───Release-dll
+        │   │   ├───Release-dll-xp
+        │   │   ├───Release-static
+        │   │   └───Release-static-xp
+        │   └───VS2017
+        │       ├───Debug-dll
+        │       ├───Debug-static
+        │       ├───Release-dll
+        │       └───Release-static
+        └───x86_64
+            ├───MinGW
+            │   ├───shared
+            │   │   └───mingw64
+            │   │       ├───bin
+            │   │       ├───include
+            │   │       └───lib
+            │   │           └───pkgconfig
+            │   └───static
+            │       └───mingw64
+            │           ├───include
+            │           └───lib
+            │               └───pkgconfig
+            ├───VS2013
+            │   ├───Release-dll
+            │   └───Release-static
+            ├───VS2015
+            │   ├───Debug-dll
+            │   ├───Debug-static
+            │   ├───Release-dll
+            │   └───Release-static
+            └───VS2017
+                ├───Debug-dll
+                ├───Debug-static
+                ├───Release-dll
+                └───Release-static
   ```
 
 ## Compile
 
 - download and unzip `xmr-stak-nvidia`
 - open a command line `cmd`
-- goto your unzipped source code
-- run (the path to VS2017 can be differ)
+- `cd` to your unzipped source code directory
+- execute the following commands (NOTE: path to VS2017 can be different)
   ```
   "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
-  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\microhttpd
+  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-static
   mkdir build
   cd build
   cmake -G "Visual Studio 15 2017 Win64" -T v140,host=x64 ..
@@ -72,4 +141,4 @@
   cd bin\Release
   copy ..\..\..\config.txt .
   ```
-- add the pool, pool-password and pool-username to `config.txt`
+- customize your `config.txt` file by adding the pool, username and password

--- a/WINCOMPILE.md
+++ b/WINCOMPILE.md
@@ -1,0 +1,75 @@
+# Compile **xmr-stak** for Windows
+
+**warning** CUDA 8 is not supporting VS2017 therefore do not miss the CMake option `-T v140,host=x64`
+
+## Install Dependencies
+
+### Preparation
+
+- open a command line `cmd`
+- run `mkdir C:\xmr-stak-dep`
+
+### Visual Studio 2017 Community
+
+- download VS2017 Community and install from [https://www.visualstudio.com/downloads/](https://www.visualstudio.com/downloads/)
+- during the install chose the components
+  - `Desktop development with C++` (left side)
+  - `Toolset for Visual Studio C++ 2015.3 v140...` (left side)
+
+### Cuda 8.0+
+
+- donwload and install https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads)
+- for minimal install choose `Custom installation options` during the install and select
+    - CUDA/Develpment
+    - CUDA/Visual Studio Integration (ignore the warning during the install that VS2017 is not supported)
+    - CUDA/Runtime
+    - Driver components
+
+### CMake for Win64
+
+- download and install the latest version from [https://cmake.org/download/](https://cmake.org/download/)
+- tested version: [cmake 3.9](https://cmake.org/files/v3.9/cmake-3.9.0-rc3-win64-x64.msi)
+- during the install choose the option `Add CMake to the system PATH for all users`
+
+### OpenSSL for Win64
+
+- download and install the precompiled binary form [https://slproweb.com/products/Win32OpenSSL.html](https://slproweb.com/products/Win32OpenSSL.html)
+- tested version: [OpenSSL 1.0.2L](https://slproweb.com/download/Win64OpenSSL-1_0_2L.exe)
+
+### Microhttpd for Win32
+
+- download the precompiled binary from [http://ftpmirror.gnu.org/libmicrohttpd/](http://ftpmirror.gnu.org/libmicrohttpd/)
+- tested version: [microhttpd-0.9.55](http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-0.9.55-w32-bin.zip)
+- unzip microhttpd to ``C:\xmr-stak-dep`
+
+### Validate the Dependency Folder
+
+- open a command line `cmd`
+- run
+   ```
+   cd c:\xmr-stak-dep
+   tree
+   ```
+- the result should have the same structure
+  ```
+    C:\XMR-STAK-DEP
+    └───microhttpd
+  ```
+
+## Compile
+
+- download and unzip `xmr-stak-nvidia`
+- open a command line `cmd`
+- goto your unzipped source code
+- run (the path to VS2017 can be differ)
+  ```
+  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
+  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\microhttpd
+  mkdir build
+  cd build
+  cmake -G "Visual Studio 15 2017 Win64" -T v140,host=x64 ..
+  msbuild xmr-stak-nvidia.sln /p:Configuration=Release
+  cd bin\Release
+  copy ..\..\..\config.txt .
+  ```
+- add the pool, pool-password and pool-username to `config.txt`


### PR DESCRIPTION
add documentation howto install all dependencies and compile with VS2017

To follow the instructions you need #57 as code base 

- [ ] must be merged after #57
- [x] tests Windows 10
- [x] tests Windows 7
