### PR TITLE
fix wrong error message

### DIFF
--- a/nvcc_code/cuda_extra.cu
+++ b/nvcc_code/cuda_extra.cu
@@ -246,10 +246,13 @@ extern "C" int cuda_get_devicecount( int* deviceCount)
 	err = cudaGetDeviceCount(deviceCount);
 	if(err != cudaSuccess)
 	{
-		if(err != cudaErrorNoDevice)
+		if(err == cudaErrorNoDevice)
 			printf("No CUDA device found!\n");
+		else if(err == cudaErrorInsufficientDriver)
+			printf("Insufficient driver!\n");
 		else
 			printf("Unable to query number of CUDA devices!\n");
+		CUDA_CHECK(-1,err);
 		return 0;
 	}
 


### PR DESCRIPTION
This bugfix is not fixing #39 but will provide the correct error message to solve the issue.

- fix wrong error message
- add error message for `cudaErrorInsufficientDriver`
- add original CUDA error message